### PR TITLE
Catalog generator cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,24 @@ Documentation:
 * [https://github.com/wanadev/obsidian-assets-manager/tree/master/doc](https://github.com/wanadev/obsidian-assets-manager/tree/master/doc)
 
 
+## CLI Tool: catalog generator
+
+`obsidian-catalog` extracts data from Obsidian Pack files and generates an Obsidian Catalog file.
+
+    Usage: obsidian-catalog [options] <packFiles>
+
+    Options:
+      --output, -o        Output file (print to stdout if not defined)      [string]
+      --pretty-print, -p  Makes the output JSON human-readable             [boolean]
+      --version, -v       Show version number                              [boolean]
+      --help, -h          Show help                                        [boolean]
+
+Examples:
+
+    $ obsidian-catalog assets1.opak assets2.opak
+    $ obsidian-catalog -o catalog.json assets.opak
+
+
 ## Changelog
 
 * **1.0.1**:

--- a/bin/obsidian-catalog
+++ b/bin/obsidian-catalog
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+
+"use strict";
+
+var fs = require("fs");
+
+var yargs = require("yargs");
+
+var pkg = require("../package.json");
+var ObsidianPackFile = require("obsidian-pack");
+
+function getPackIndex(pack) {
+    var index = {};
+    var assetList = pack.assetList;
+    for (var i = 0 ; i < assetList.length ; i++) {
+        var assetName = assetList[i];
+        index[assetName] = pack.getAssetRecord(assetName);
+    }
+    return index;
+}
+
+var argv = yargs
+
+    .option("output", {
+        describe: "Output file (print to stdout if not defined)",
+        alias: "o",
+        nargs: 1,
+        normalize: true
+    })
+
+    .option("pretty-print", {
+        describe: "Makes the output JSON human-readable",
+        alias: "p",
+        type: "boolean"
+    })
+
+    .version(pkg.version).alias("version", "v")
+    .usage("Usage: obsidian-catalog [options] <packFiles>")
+    .help().alias("help", "h")
+    .example("obsidian-catalog assets1.opak assets2.opak")
+    .example("obsidian-catalog -o catalog.json assets.opak")
+    .locale("en")
+    .argv;
+
+var catalog = {
+    packages: {}
+};
+
+for (var i = 0 ; i < argv._.length ; i++) {
+    var packBin = fs.readFileSync(argv._[i]);
+    var pack = new ObsidianPackFile(packBin);
+    catalog.packages[pack.packName] = getPackIndex(pack);
+}
+
+var catalogStr = JSON.stringify(catalog, null, argv["pretty-print"] ? 2 : 0);
+
+if (argv.output) {
+    fs.writeFileSync(argv.output, catalogStr);
+} else {
+    console.log(catalogStr);
+}

--- a/bin/obsidian-catalog
+++ b/bin/obsidian-catalog
@@ -3,6 +3,7 @@
 "use strict";
 
 var fs = require("fs");
+var path = require("path");
 
 var yargs = require("yargs");
 
@@ -47,9 +48,13 @@ var catalog = {
 };
 
 for (var i = 0 ; i < argv._.length ; i++) {
-    var packBin = fs.readFileSync(argv._[i]);
+    var packPath = argv._[i];
+    var packBin = fs.readFileSync(packPath);
     var pack = new ObsidianPackFile(packBin);
-    catalog.packages[pack.packName] = getPackIndex(pack);
+    catalog.packages[pack.packName] = {
+        url: path.basename(packPath),
+        assets: getPackIndex(pack)
+    };
 }
 
 var catalogStr = JSON.stringify(catalog, null, argv["pretty-print"] ? 2 : 0);

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "start": "pm2 start -f test/server/server.js --name=obsidian-proxy-server-test --watch && sleep 1",
     "stop": "pm2 delete obsidian-proxy-server-test"
   },
+  "directories": {
+    "bin": "./bin"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/wanadev/obsidian-assets-manager.git"
@@ -24,7 +27,8 @@
     "obsidian-http-request": "^1.1.4",
     "obsidian-pack": "1.0.0",
     "q": "^1.4.1",
-    "uuid": "^2.0.3"
+    "uuid": "^2.0.3",
+    "yargs": "^6.0.0"
   },
   "devDependencies": {
     "body-parser": "^1.15.2",


### PR DESCRIPTION
This PR adds a CLI tool to generates catalog file from given `*.opak` files.

```
Usage: obsidian-catalog [options] <packFiles>

Options:
  --output, -o        Output file (print to stdout if not defined)      [string]
  --pretty-print, -p  Makes the output JSON human-readable             [boolean]
  --version, -v       Show version number                              [boolean]
  --help, -h          Show help                                        [boolean]

Examples:
  obsidian-catalog assets1.opak assets2.opak
  obsidian-catalog -o catalog.json assets.opak
```
