### PR TITLE
Fixes tests failling because of daemonized PM2 never killed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,7 @@ node_js:
     - "stable"
 before_script:
     - ./node_modules/.bin/pm2 start -f test/server/server.js --name=obsidian-proxy-server-test &
-script: grunt jshint browserify:test mocha_phantomjs
+script:
+    - grunt jshint browserify:test mocha_phantomjs
+after_script:
+    - ./node_modules/.bin/pm2 kill


### PR DESCRIPTION
Adds an `after_script` target in `.travis.yml` to kill PM2 after tests finished